### PR TITLE
fix healthcheck pings timing out on connect

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@
    b. make a stagedUploads graphql request to get an upload url (shopify does not allow us to upload directly- instead we upload via a pre-signed upload URL that points to storage infrastructure associated with their CDN. Uploading to this URL sends the file data directly to the storage endpoint, bypassing Shopify’s main application servers)
    c. upload the file to the returned target upload url
    d. "register" the file so that is avaliable in our CDN
-5. do a cleanup of all files in uploads older than 30 days
+5. do a cleanup of all files in uploads older than 15 days
 
 ## Project notes + challenges
 

--- a/upload-app/src/index.ts
+++ b/upload-app/src/index.ts
@@ -17,7 +17,7 @@ fs.mkdir(uploadsDir, { recursive: true }, (err) => {
   }
 });
 
-// run the cleanup func every day, remove files older than 30 days
+// run the cleanup func every day, remove files older than 15 days
 const CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000; // every 24 hours
 setInterval(cleanupOldFiles, CLEANUP_INTERVAL_MS);
 
@@ -159,7 +159,14 @@ async function main() {
               }
             `;
           // Get stats for the processed file
-          const processedStats = await fs.promises.stat(processedFilePath);
+          let processedStats;
+          try {
+            processedStats = await fs.promises.stat(processedFilePath);
+          } catch (e) {
+            console.error(`Failed to stat ${processedFilePath}:`, e);
+            await pingHealthcheck(true);
+            return;
+          }
 
           const variables = {
             input: [
@@ -204,9 +211,15 @@ async function main() {
             formData.append(param.name, param.value);
           });
           // Read your file into a buffer
-          const fileBuffer = await readFile(processedFilePath);
-          const file = new File([fileBuffer], filename);
-          formData.append("file", file, "eb-soh.csv");
+          try {
+            const fileBuffer = await readFile(processedFilePath);
+            const file = new File([fileBuffer], filename);
+            formData.append("file", file, "eb-soh.csv");
+          } catch (e) {
+            console.error(`Failed to read ${processedFilePath}:`, e);
+            await pingHealthcheck(true);
+            return;
+          }
 
           try {
             const response = await fetch(uploadUrl, {

--- a/upload-app/src/utils/healthcheck.ts
+++ b/upload-app/src/utils/healthcheck.ts
@@ -1,6 +1,14 @@
+import { setDefaultAutoSelectFamilyAttemptTimeout } from "net";
+
 import { readDockerSecret } from "./readDockerSecret.js";
 
 const SECRET_NAME = "eb_stock_on_hand_file_upload_healthcheck_url";
+
+// hc-ping.com sits ~260ms from the droplet, just past node's 250ms default
+// per-address connect budget. Without this every attempt is abandoned
+// mid-handshake and reported as ETIMEDOUT, indistinguishable from a firewall
+// drop. The AbortSignal below bounds the whole request, not each attempt.
+setDefaultAutoSelectFamilyAttemptTimeout(5_000);
 
 let cachedUrl: string | null | undefined;
 


### PR DESCRIPTION
hc-ping.com resolves to Hetzner IPs ~260ms from the droplet, just past node's 250ms default autoSelectFamily per-address connect budget. Every attempt was abandoned mid-handshake and surfaced as ETIMEDOUT with syscall 'connect' — indistinguishable from a firewall drop. Raise the attempt timeout to 5s. The existing AbortSignal.timeout bounds the whole request, not each attempt, so it never helped.

Uploads to Shopify were unaffected throughout; only the ping failed.

Also close two silent-crash paths in the watch callback: fs.stat and readFile sat outside any try inside an un-awaited async callback, so a throw became an unhandled rejection that killed the process without pinging /fail — a failure mode that looks identical to no file arriving.

Correct the retention comments to 15 days to match FILE_AGE in cleanup.ts, changed deliberately in 89c94d2 but never reflected here.